### PR TITLE
Хотфикс автовыплат

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -1,6 +1,4 @@
-using System.Globalization;
-using System.Linq;
-using System.Numerics;
+using Content.Server._Corvax.Respawn; // Frontier
 using Content.Server.Administration.Managers;
 using Content.Server.Administration.Systems;
 using Content.Server.GameTicking.Events;
@@ -8,6 +6,8 @@ using Content.Server.Ghost;
 using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
 using Content.Server.Station.Components;
+using Content.Server._Lua.AutoSalarySystem; // Lua
+using Content.Shared._NF.Roles.Components; // Frontier
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind;
@@ -22,8 +22,9 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Server._Corvax.Respawn; // Frontier
-using Content.Shared._NF.Roles.Components; // Frontier
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
 
 namespace Content.Server.GameTicking
 {
@@ -263,13 +264,15 @@ namespace Content.Server.GameTicking
             // Frontier: ensure jobs are tracked
             var jobComp = EnsureComp<JobTrackingComponent>(mob);
             jobComp.Job = jobId;
+            var salary = EnsureComp<SalaryTrackingComponent>(mob);
+            salary.Station = station;
+            salary.JobId = jobId;
             jobComp.SpawnStation = station;
             jobComp.Active = true;
             Dirty(mob, jobComp);
             // End Frontier
 
             _roles.MindAddJobRole(newMind, silent: silent, jobPrototype:jobId);
-            _stationJobs.TryAssignJob(station, jobPrototype, player.UserId);
             var jobName = _jobs.MindTryGetJobName(newMind);
             _admin.UpdatePlayerList(player);
 

--- a/Content.Server/_Lua/AutoSalarySystem/AutoSalarySystem.cs
+++ b/Content.Server/_Lua/AutoSalarySystem/AutoSalarySystem.cs
@@ -7,7 +7,6 @@ using Content.Server.Chat.Managers; // Lua
 using Content.Server.Popups; // Lua
 using Content.Server.Station.Systems; // Lua
 using Content.Shared._NF.Bank.Components;
-using Content.Shared._NF.Roles.Components;
 using Content.Shared.Chat; // Lua
 using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;
@@ -25,7 +24,6 @@ public sealed class AutoSalarySystem : EntitySystem
     [Dependency] private readonly BankSystem _bank = default!;
     [Dependency] private readonly PopupSystem _popup = default!; // Lua
     [Dependency] private readonly IChatManager _chatManager = default!; // Lua
-    [Dependency] private readonly StationJobsSystem _stationJobs = default!; // Lua
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // Lua
     [Dependency] private readonly IConfigurationManager _cfg = default!; // Lua
 
@@ -48,7 +46,7 @@ public sealed class AutoSalarySystem : EntitySystem
 
         if (_currentTime <= 0)
         {
-            _currentTime = _interval;
+            _currentTime = _cfg.GetCVar(CLVars.AutoSalaryInterval);
             ProcessSalary();
         }
     }
@@ -61,23 +59,20 @@ public sealed class AutoSalarySystem : EntitySystem
     // Lua start
     private void ProcessSalary()
     {
-        var query = EntityQueryEnumerator<HumanoidAppearanceComponent, BankAccountComponent, ActorComponent>();
-        while (query.MoveNext(out var uid, out _, out _, out var actor))
+        var query = EntityQueryEnumerator<HumanoidAppearanceComponent, BankAccountComponent, ActorComponent, SalaryTrackingComponent>();
+        while (query.MoveNext(out var uid, out _, out _, out var actor, out var salary))
         {
-            var station = GetOwningStation(uid);
-            if (station == null)
+            if (string.IsNullOrEmpty(salary.JobId))
                 continue;
 
-            if (TryComp<JobTrackingComponent>(uid, out var jobTracking) &&
-                jobTracking.Active &&
-                _stationJobs.TryGetOriginalJob(station.Value, actor.PlayerSession.UserId, out var jobId))
+            if (!_prototypeManager.TryIndex(new ProtoId<JobPrototype>(salary.JobId), out var job))
+                continue;
+
+            Logger.Info($"DEBUG: {ToPrettyString(uid)} jobID: {salary.JobId}");
+            var amount = job.Salary;
+            if (_bank.TryBankDeposit(uid, amount))
             {
-                Logger.Info($"DEBUG: {ToPrettyString(uid)} оригинальный JobID: {jobId}");
-                var salary = GetSalary(jobId);
-                if (_bank.TryBankDeposit(uid, salary))
-                {
-                    NotifySalaryReceived(uid, salary);
-                }
+                NotifySalaryReceived(uid, amount);
             }
         }
     }

--- a/Content.Server/_Lua/AutoSalarySystem/SalaryTrackingComponent.cs
+++ b/Content.Server/_Lua/AutoSalarySystem/SalaryTrackingComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server._Lua.AutoSalarySystem;
+
+[RegisterComponent]
+public sealed partial class SalaryTrackingComponent : Component
+{
+    [DataField] public EntityUid Station;
+    [DataField] public string JobId = string.Empty;
+}


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/ru/getting-started/pr-guideline -->

## О пулл-реквесте
Привязка автовыплат перенесена в компонент из-за ошибки выплат, текущие выплаты работают на станции где появился персонаж из-за GetOwningStation

## Обоснование / Баланс
Исправляет проблему отсутствия автовыплат

## Технические детали
Создан компонент SalaryTrackingComponent
Компонент назначается в методе SpawnPlayer

## Как протестировать
Перейти на другой грид или в космос - убедиться что зарплата поступает
Открыть vv игрока - убедиться в наличии компонента SalaryTrackingComponent

## Медиа
![image](https://github.com/user-attachments/assets/c33c4427-3384-4db7-8463-f11f40a72650)

## Требования
<!-- Подтвердите следующее, поставив X в квадратных скобках [X]: -->
- [x] Я прочитал [CONTRIBUTING.md](https://github.com/HacksLua/sector-frontier/blob/master/CONTRIBUTING.md) и соблюдаю [Руководство по пулл-реквестам и изменению логов](https://docs.spacestation14.com/ru/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я приложил медиа-материалы к этому PR или они не требуются.
- [x] Я ознакомился с [Руководством по добавлению кораблей](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines), если это уместно.
- [x] Я подтверждаю, что ИИ-инструменты не использовались для создания материалов в этом PR.
<!-- Имейте в виду, что несоблюдение этих требований может привести к закрытию PR по усмотрению мейнтейнера -->

## Критические изменения
Нету

**Журнал изменений**
<!-- Добавьте запись в журнал изменений, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на геймплей.
Убедитесь, что прочитали руководство и удалите этот шаблон из комментария, чтобы он отобразился.
Запись должна содержать символ :cl:, чтобы бот распознал изменения и добавил их в игровой журнал изменений. -->

:cl:
- fix: Автовыплаты теперь не зависят от грида

